### PR TITLE
docs: correcting the usage of the set state calls in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ const PaymentForm = () => {
   const handleInputChange = (evt) => {
     const { name, value } = evt.target;
     
-    setState({ [name]: value });
+    setState((prev) => ({ ...prev, [name]: value }));
   }
 
   const handleInputFocus = (evt) => {
-    setState({ focus: evt.target.name });
+    setState((prev) => ({ ...prev, focus: evt.target.name }));
   }
 
   return (


### PR DESCRIPTION
I made a mistake earlier in the docs (in #4), and used the Class components method of setting the state, instead of the useState method of spreading the existing state.

This corrects it to `setState((prev) => ({ ...prev, [name]: value }))`