### PR TITLE
build: revert back to the build output prior to the ts migration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
   "plugins": ["@typescript-eslint", "prettier"],
   "extends": ["plugin:@typescript-eslint/recommended", "react-app", "prettier"],
   "rules": {
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-var-requires": "off"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ lib/
 node_modules/
 webpack.stats.json
 dist/
+index.d.ts
 
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -19,27 +19,27 @@ npm install --save react-credit-cards-2
 ### Usage
 
 ```tsx
-import React, { useState } from 'react';
-import Cards from 'react-credit-cards-2';
+import React, { useState } from "react";
+import Cards from "react-credit-cards-2";
 
 const PaymentForm = () => {
   const [state, setState] = useState({
-    number: '',
-    expiry: '',
-    cvc: '',
-    name: '',
-    focus: '',
+    number: "",
+    expiry: "",
+    cvc: "",
+    name: "",
+    focus: "",
   });
 
   const handleInputChange = (evt) => {
     const { name, value } = evt.target;
-    
+
     setState((prev) => ({ ...prev, [name]: value }));
-  }
+  };
 
   const handleInputFocus = (evt) => {
     setState((prev) => ({ ...prev, focus: evt.target.name }));
-  }
+  };
 
   return (
     <div>
@@ -63,20 +63,20 @@ const PaymentForm = () => {
       </form>
     </div>
   );
-}
+};
 
 export default PaymentForm;
 ```
 
-If you are using SASS, import the CSS `react-credit-cards-2/dist/lib/styles.scss` 
+If you are using SASS, import the CSS `react-credit-cards-2/lib/styles.scss`
 
 Or you can import the CSS:  
-`import 'react-credit-cards-2/dist/es/styles-compiled.css';`
+`import 'react-credit-cards-2/es/styles-compiled.css';`
 
 ### Features
 
 - We support all credit card issuers available in [credit-card-type](https://github.com/braintree/credit-card-type) plus
- Dankort, Laser, and Visa Electron.
+  Dankort, Laser, and Visa Electron.
 
 ## Props
 
@@ -143,32 +143,32 @@ Here's how you can get started developing locally:
 
 1. Clone this repo and link it to your global `node_modules`:
 
-      $ git clone https://github.com/felquis/react-credit-cards-2.git
+   $ git clone https://github.com/felquis/react-credit-cards-2.git
 
-      $ cd react-credit-cards-2
+   $ cd react-credit-cards-2
 
-      $ npm install
+   $ npm install
 
-      $ npm link
+   $ npm link
 
 2. Download the demo source from [codesandbox](https://codesandbox.io/s/ovvwzkzry9).
 3. Unzip it to the desired directory.
 4. Install the dependencies
 
-    $ cd react-credit-cards-demo
+   $ cd react-credit-cards-demo
 
-    $ npm install
+   $ npm install
 
-    $ npm link react-credit-cards
+   $ npm link react-credit-cards
 
 5. On the `react-credit-cards` directory, start the watcher:
 
-    $ npm run watch
-    
+   $ npm run watch
+
 6. On the `react-credit-cards-demo` directory, start the demo app:
 
-    $ npm start
-    
+   $ npm start
+
 7. 🎉 Done! The demo app will be running on: `http://localhost:3000/`. Your local changes should be automatically reflected there.
 
 Check [npm-link](https://docs.npmjs.com/cli/link.html) for detailed instructions.
@@ -189,4 +189,5 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduc
 This project is licensed under the [MIT License](LICENSE.md).
 
 ###### Made with ❤️ at [AMARO](https://amaro.com).
+
 ###### Maintained with ❤️ by the community

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import ReactCreditCards, { Focused } from "../..";
 import "./App.css";
-import "../../dist/es/styles-compiled.css";
+import "../../es/styles-compiled.css";
 
 // https://stripe.com/docs/testing
 const CardNumbers = [

--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
   },
   "homepage": "https://github.com/felquis/react-credit-cards-2#readme",
   "license": "MIT",
-  "main": "dist/lib/index.js",
-  "module": "dist/es/index.js",
-  "types": "dist/index.d.ts",
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "types": "index.d.ts",
   "files": [
-    "dist"
+    "es",
+    "lib",
+    "index.d.ts"
   ],
   "keywords": [
     "react",
@@ -116,7 +118,7 @@
     "build:styles": "node tools/build-styles",
     "build": "npm run clean && npm run build:code && npm run build:styles",
     "watch": "npm run build && watch-run -p 'src/**/.{ts,tsx,scss}' npm run build",
-    "clean": "rimraf dist/ es/ lib/ coverage/ .tmp/",
+    "clean": "rimraf es/ lib/ coverage/ .tmp/ index.d.ts",
     "lint": "eslint --max-warnings=0 src",
     "format": "prettier --write './src/**/*.{js,jsx,ts,tsx,css,md,json}' --config ./prettier.config.cjs",
     "lint:styles": "stylelint 'src/**/*.scss'",
@@ -133,11 +135,11 @@
   ],
   "size-limit": [
     {
-      "path": "./dist/es/index.js",
+      "path": "./es/index.js",
       "limit": "6 kB"
     },
     {
-      "path": "./dist/lib/index.js",
+      "path": "./lib/index.js",
       "limit": "6 kB"
     }
   ],

--- a/rollup.config.cjs
+++ b/rollup.config.cjs
@@ -35,7 +35,7 @@ module.exports = [
     ],
   },
   {
-    input: "dist/es/types/index.d.ts",
+    input: "es/types/index.d.ts",
     output: [{ file: packageJson.types, format: "esm" }],
     external: [/\.css$/],
     plugins: [dts()],

--- a/tools/build-styles.js
+++ b/tools/build-styles.js
@@ -12,13 +12,9 @@ run("rm -rf .tmp/")
   .then(() => run("mv .tmp/styles.css .tmp/styles-compiled.css"))
   // .then(() => run("mkdir -p dist/es dist/lib"))
   .then(() =>
-    run(
-      "cp .tmp/styles-compiled.css dist/es/ && cp .tmp/styles-compiled.css dist/lib/"
-    )
+    run("cp .tmp/styles-compiled.css es/ && cp .tmp/styles-compiled.css lib/")
   )
-  .then(() =>
-    run("cp src/styles.scss dist/es/ && cp src/styles.scss dist/lib/")
-  )
+  .then(() => run("cp src/styles.scss es/ && cp src/styles.scss lib/"))
   .then(() => console.log("✔ Styles have been build"))
   .catch((err) => {
     console.error(err);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "esnext",
     "jsx": "react",
     "sourceMap": true,
-    "outDir": "dist",
+    "outDir": ".",
     "strict": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
# Description
Reverting the file structure, used before the changes introduced to the build-step in the migration to typescript. This change inadvertently introduced a breaking change, requiring users to import the stylesheets from the `dist` folder.

Old: `import from 'react-credit-cards-2/es/styles-compiled.css'`
Borked New: `import from 'react-credit-cards-2/dist/es/styles-compiled.css'`

As such, a patch was released in #12 that updated the docs, with the patched imports.

This PR, matches the build-step to what was being used previously. Going forward, those who install the package should be able to use it as a drop-in replacement for the main package of `react-credit-cards`.

# File structure
Accordingly, this is the file structure that is being re-introduced into the build process.

```
es/
└─ /* Contains the bundled esm code, including the .scss and compiled .css stylesheets. */
lib/
└─ /* Contains the bundled commonjs code, including the .scss and compiled .css stylesheets. */
index.d.ts
└─ /* The typescript type declarations file. */
```