### PR TITLE
Add maestro to maxLength 19 card types

### DIFF
--- a/src/ReactCreditCards.tsx
+++ b/src/ReactCreditCards.tsx
@@ -73,7 +73,7 @@ export function ReactCreditCards(props: ReactCreditCardsProps) {
       maxLength = 15;
     } else if (cardTypesMap?.dinersclub.includes(updatedIssuer)) {
       maxLength = 14;
-    } else if (["hipercard", "mastercard", "visa"].includes(updatedIssuer)) {
+    } else if (["hipercard", "maestro", "mastercard", "visa"].includes(updatedIssuer)) {
       maxLength = 19;
     }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -251,7 +251,7 @@ describe("ReactCreditCards", () => {
     );
     expect(mockCallback).toHaveBeenCalled();
     expect(mockCallback.mock.calls[0][0]).toStrictEqual({
-      maxLength: 16,
+      maxLength: 19,
       issuer: "maestro",
     });
   });


### PR DESCRIPTION
Extended maestro card support to allow up to 19 digits. 

REASON FOR UPDATE:
There are real maestro cards that have more than 16 digits length, but the library doesn't support it.
Please see possible maxLength from the[ credit-card-type library.](https://github.com/braintree/credit-card-type/blob/main/src/lib/card-types.ts) Maxlength could be 19, so proper update for the library.
<img width="471" height="407" alt="image" src="https://github.com/user-attachments/assets/3eaad647-f964-4c01-82f5-4461aeeadfd3" />
